### PR TITLE
Fix broken API calls

### DIFF
--- a/bookworm.ipynb
+++ b/bookworm.ipynb
@@ -450,9 +450,9 @@
    "outputs": [],
    "source": [
     "# A simple query\n",
-    "results = discovery.query(environment_id=env_id, collection_id=col_id,\n",
+    "results = discovery.query(environment_id=env_id, collection_id=col_id, count=5\n",
+    "    query: \"enriched_text.relations.subject.text:\\\"Jar Jar\\\"\",\n",
     "    query_options={\n",
-    "        \"query\": \"enriched_text.relations.subject.text:\\\"Jar Jar\\\"\",\n",
     "        \"return\": \"metadata.title,text\"\n",
     "    }).get_result()\n",
     "print(json.dumps(results, indent=2))"
@@ -822,8 +822,8 @@
    "source": [
     "# TODO: Query the Discovery service based on the intent and entities\n",
     "query_results = discovery.query(environment_id=env_id, collection_id=col_id,\n",
+    "    query: \"text:{}\".format(\",\".join(\"\\\"{}\\\"\".format(e) for e in query_entities)),\n",
     "    query_options={\n",
-    "        \"query\": \"text:{}\".format(\",\".join(\"\\\"{}\\\"\".format(e) for e in query_entities)),\n",
     "        \"return\": \"text\"\n",
     "    }).get_result()\n",
     "print(json.dumps(query_results, indent=2))"


### PR DESCRIPTION
The older version is no longer supported. Upgrading the version to "2018-12-03" so that the rest of the code cells don't break. 