### PR TITLE
Updated the tutorial to work with the new ibm-watson API

### DIFF
--- a/bookworm.ipynb
+++ b/bookworm.ipynb
@@ -80,7 +80,17 @@
     "# Install watson-developer-cloud\n",
     "# This takes about a minute\n",
     "\n",
-    "!pip install --upgrade \"watson-developer-cloud>=2.4.1\""
+    "# !pip install --upgrade \"watson-developer-cloud>=2.4.1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade \"ibm-watson>=4.2.1\"\n",
+    "!pip install --upgrade \"ibm-cloud-sdk-core==1.5.1\""
    ]
   },
   {
@@ -103,9 +113,8 @@
     "%matplotlib inline\n",
     "\n",
     "# Watson Python SDK\n",
-    "# If not installed run: \n",
-    "# !pip install --upgrade watson-developer-cloud\n",
-    "import watson_developer_cloud\n",
+    "from ibm_watson import DiscoveryV1, AssistantV1\n",
+    "from ibm_cloud_sdk_core.authenticators import IAMAuthenticator\n",
     "\n",
     "# Utility functions\n",
     "%load_ext autoreload\n",
@@ -139,10 +148,11 @@
    "source": [
     "discovery_creds = helper.fetch_credentials('discovery')\n",
     "\n",
-    "discovery = watson_developer_cloud.DiscoveryV1(\n",
-    "                        version='2018-08-01',\n",
-    "                        url=discovery_creds['url'],\n",
-    "                        iam_apikey=discovery_creds['apikey'])"
+    "authenticator = IAMAuthenticator(apikey=discovery_creds['apikey'])\n",
+    "\n",
+    "discovery = DiscoveryV1(version='2018-12-03',\n",
+    "                        authenticator=authenticator)\n",
+    "discovery.set_service_url(discovery_creds['url'])"
    ]
   },
   {
@@ -161,9 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Prepare an environment to work in\n",
@@ -219,96 +227,6 @@
     "3. **normalizations**: Post-processing steps to be applied to the output. This can be left empty in most cases, unless you need the output to be normalized into a very specific format.\n",
     "\n",
     "_**Note**: The default configuration for an environment cannot be modified. If you need to change any of the options, you will need to create a new one, and then edit it. The easiest way to do this is using the service dashboard, which is described later._"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Testing Language Enrichment\n",
-    "\n",
-    "It is a good idea to test your configuration on a small sample text before you apply it to a larger document collection.\n",
-    "\n",
-    "_**Note**: We have supplied a sample document (`data/sample.html`) containing the opening crawl text for Star Wars: Episode IV, but you are free to use a text of your choosing._\n",
-    "\n",
-    "**Q**: (optional) If you use your own sample text, provide a brief title and description below.\n",
-    "\n",
-    "**A**: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "# Test configuration on some sample text\n",
-    "data_dir = \"data\"\n",
-    "filename = os.path.join(data_dir, \"sample.html\")\n",
-    "with open(filename, \"r\") as f:\n",
-    "    res = discovery.test_configuration_in_environment(environment_id=env_id, configuration_id=cfg_id, file=f).get_result()\n",
-    "print(json.dumps(res, indent=2))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Analyze test output\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The results returned by the service contain a _snapshot_ of the information extracted at each step of processing - document conversions, enrichments and normalizations. We are interested in the output of applying enrichments (\"enrichments_output\") or after normalizing them (\"normalizations_output\"). These should be identical if no post-processing/normalizations were specified in the configuration."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Take a closer look at the results from the \"enrichments_output\" or \"normalizations_output\" step\n",
-    "output = next((s[\"snapshot\"] for s in res[\"snapshots\"] if s[\"step\"] == \"enrichments_output\"), None)\n",
-    "print(json.dumps(output, indent=2))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Answer the following questions based on the output above. Note that it contains the input HTML, extracted text and metadata as well as the actual enrichment results.\n",
-    "\n",
-    "#### Sentiment\n",
-    "\n",
-    "**Q**: What is the overall sentiment detected in this text? Mention the `type` (positive/negative) and `score`.<br />\n",
-    "(_Hint: Look for the `\"sentiment\"` key in the output._)\n",
-    "\n",
-    "**A**: \n",
-    "\n",
-    "\n",
-    "#### Concepts\n",
-    "\n",
-    "**Q**: List 3 concepts that have been identified with a relevance > 0.5. Note that not all concepts here may be present directly in the text, some may have been inferred by Watson.<br />\n",
-    "(_Hint: Look for `\"concepts\"`._)\n",
-    "\n",
-    "**A**:\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "\n",
-    "Get a good sense of all the different pieces of information available in the results. Start thinking about which ones will be useful for looking up answers to questions, and how you might use them."
    ]
   },
   {
@@ -377,6 +295,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "data_dir = \"data\"\n",
     "# Add documents to collection\n",
     "doc_ids = []  # to store the generated id for each document added\n",
     "for filename in glob.glob(os.path.join(data_dir, \"Star-Wars\", \"*.html\")):\n",
@@ -593,13 +512,13 @@
    "source": [
     "# Connect to the Assistant service instance\n",
     "# TODO: Enter your username and password from the Service Credentials tab in service-credentials.json\n",
-    "\n",
+    "# Watson Python SDK\n",
     "assistant_cred = helper.fetch_credentials('assistant')\n",
+    "authenticator = IAMAuthenticator(apikey=assistant_cred['apikey'])\n",
     "\n",
-    "assistant = watson_developer_cloud.AssistantV1(\n",
-    "                        version='2018-08-01',\n",
-    "                        url=assistant_cred['url'],\n",
-    "                        iam_apikey=assistant_cred['apikey'])"
+    "assistant = AssistantV1(version='2018-12-03',\n",
+    "                        authenticator=authenticator)\n",
+    "assistant.set_service_url(assistant_cred['url'])"
    ]
   },
   {
@@ -768,7 +687,7 @@
     "# TODO: Run a sample question through Assistant service\n",
     "\n",
     "# Then ask a sample question\n",
-    "question= \"Where was Luke born?\"\n",
+    "question = \"Where was Luke born?\"\n",
     "results = assistant.message(workspace_id=wrk_id,\n",
     "                            input={'text': question}, context=context).get_result()\n",
     "\n",
@@ -805,7 +724,7 @@
    "source": [
     "### Query the collection\n",
     "\n",
-    "Design a query based on the information extracted above, and run it against the document collection. The sample query provided below simple looks for all the entities in the raw `text` field. Modify it to suit your needs.\n",
+    "Design a query based on the information extracted above, and run it against the document collection. The sample query provided below simply looks for all the entities in the raw `text` field. Modify it to suit your needs.\n",
     "\n",
     "Take a look at the [API Reference](https://www.ibm.com/watson/developercloud/discovery/api/v1/?python#query-collection) to learn more about the query options available, and for more guidance see this [documentation page](https://www.ibm.com/watson/developercloud/doc/discovery/using.html).\n",
     "\n",
@@ -890,7 +809,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -904,7 +823,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.7.5rc1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Made the sections "Using the Service Credentials" and "Adding Entities" work with the new DiscoveryV1 and AssistantV1 API, respectively. In addition, discovery.test_configuration_in_environment() is deprecated so the section "Testing Language Enrichment" was removed. Finally, a typo was fixed ('simple' -> 'simply')